### PR TITLE
added visual confirmation when share link is copied

### DIFF
--- a/src/views/BrowserView.vue
+++ b/src/views/BrowserView.vue
@@ -3,7 +3,7 @@ import { ref, watch, inject } from 'vue'
 import InputPanel from '@/components/InputPanel.vue'
 import OutputPanel from '@/components/OutputPanel.vue'
 import DrawerPanel from '@/components/DrawerPanel.vue'
-import { uid, copyToClipboard } from 'quasar'
+import { uid, copyToClipboard, useQuasar } from 'quasar'
 import { useRoute, useRouter } from 'vue-router'
 
 const GlobalVariables = inject('GlobalVariables')
@@ -14,6 +14,7 @@ const queries = ref(route.query.session ? JSON.parse(atob(route.query.session)) 
 const outputPanel = ref()
 const outputPanelHeight = ref(`${GlobalVariables.outputPanelHeight}px`)
 const drawer = ref(true)
+const $q = useQuasar()
 
 const runQuery = (query) => {
   const uuid = uid()
@@ -32,6 +33,9 @@ const shareQuery = (query) => {
   const session = btoa(JSON.stringify([query]))
   const urlToShare = `${window.location.origin}${pathName}?session=${session}`
   copyToClipboard(urlToShare)
+    .then(() => {
+      $q.notify({ message: 'Link copied to clipboard!', color: 'positive' })
+    })
 }
 
 const updateQuery = (query, uuid) => {


### PR DESCRIPTION
Hello,
This PR implements the visual feedback requested in #19. I added a simple quasar notification that triggers after the link gets copied. Made sure to follow your 3 line suggested approach. I imported useQuasar, and added the toast in shareQuery
Screenshot:
<img width="1903" height="915" alt="Link copied to clipboard!" src="https://github.com/user-attachments/assets/3a7216ec-51b1-4847-a780-611e05fedbba" />
Tested locally and works as expected. Happy to make any changes if needed though!
Closes #19 